### PR TITLE
infra(UI): #87: update paywright to 1.55.1 to fix security issue

### DIFF
--- a/ui/.devcontainer/devcontainer.json
+++ b/ui/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// this is using playwright docker image with pre-installed browsers and their deps
 	// this image doesn't contain playwright itself
 	// https://playwright.dev/docs/docker
-	"image": "mcr.microsoft.com/playwright:v1.53.0-noble",
+	"image": "mcr.microsoft.com/playwright:v1.55.1-noble",
 	"features": {
 		// Enable VNC
 		"ghcr.io/devcontainers/features/desktop-lite:1.1.0": {},

--- a/ui/.devcontainer/e2e-tests-in-pr/devcontainer.json
+++ b/ui/.devcontainer/e2e-tests-in-pr/devcontainer.json
@@ -5,7 +5,7 @@
 	// this is using playwright docker image with pre-installed browsers and their deps
 	// this image doesn't contain playwright itself
 	// https://playwright.dev/docs/docker
-	"image": "mcr.microsoft.com/playwright:v1.53.0-noble",
+	"image": "mcr.microsoft.com/playwright:v1.55.1-noble",
 	// for now we need to install all packages but ToDo we need to install only playwright and its deps
 	"onCreateCommand": "npm ci",
 	// it is needed so that our tests can make calls to the parent container network 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.2",
-        "@playwright/test": "1.53.0",
+        "@playwright/test": "1.55.1",
         "@stylistic/eslint-plugin": "^1.6.3",
         "@stylistic/stylelint-config": "^1.0.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2597,13 +2597,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
-      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.53.0"
+        "playwright": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11480,13 +11480,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
-      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.0"
+        "playwright-core": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11499,9 +11499,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
-      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
-    "@playwright/test": "1.53.0",
+    "@playwright/test": "1.55.1",
     "@stylistic/eslint-plugin": "^1.6.3",
     "@stylistic/stylelint-config": "^1.0.1",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
Fixed vulnerabilities: Playwright downloads and installs browsers without verifying the authenticity of the SSL certificate - https://github.com/advisories/GHSA-7mvr